### PR TITLE
Added `spaceSize` option to increase spacing between columns 🪐

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The `spaceLog` function has two required arguments; `config` and `data`.
 
 - `headings`: An optional array of headings to use as the title of each column. If no headings are provided, only the data will be included in the output.
 
+- `spaceSize`: Define the space between each column. Default: 1.
+
 #### Data (array)
 
 An array of objects containing the data to log.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The `spaceLog` function has two required arguments; `config` and `data`.
 
 - `headings`: An optional array of headings to use as the title of each column. If no headings are provided, only the data will be included in the output.
 
-- `spaceSize`: Define the space between each column. Default: 1.
+- `spaceSize`: Specifies the spacing between columns. Default value is `1`.
 
 #### Data (array)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,10 @@ interface SpaceLogConfig {
 }
 
 interface SpaceLogDataItem {
-  [key: string]: string | undefined | ((text: string) => string)
+  [key: string]: any
 }
 
-function spaceLog(config: SpaceLogConfig, data: SpaceLogDataItem[]): void
+declare function spaceLog(config: SpaceLogConfig, data: Array<SpaceLogDataItem>): void
 
 export { spaceLog }
-
 export default spaceLog

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "type": "git",
     "url": "git+https://github.com/01taylop/space-log.git"
   },
-  "version": "1.1.1",
+  "version": "1.2.0-beta.2",
   "type": "module",
   "main": "./lib/index.js",
-  "types": "./spaceLog.d.ts",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",
@@ -17,7 +17,7 @@
   },
   "files": [
     "lib",
-    "spaceLog.d.ts"
+    "index.d.ts"
   ],
   "scripts": {
     "build:cjs": "babel src -d lib --env-name cjs --out-file-extension .cjs",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "version": "1.1.1",
   "type": "module",
   "main": "./lib/index.js",
+  "types": "./spaceLog.d.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",
@@ -15,7 +16,8 @@
     }
   },
   "files": [
-    "lib"
+    "lib",
+    "spaceLog.d.ts"
   ],
   "scripts": {
     "build:cjs": "babel src -d lib --env-name cjs --out-file-extension .cjs",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/01taylop/space-log.git"
   },
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./index.d.ts",

--- a/spaceLog.d.ts
+++ b/spaceLog.d.ts
@@ -1,0 +1,15 @@
+interface SpaceLogConfig {
+  columnKeys: Array<string>
+  headings?: Array<string>
+  spaceSize?: number
+}
+
+interface SpaceLogDataItem {
+  [key: string]: string | undefined | ((text: string) => string)
+}
+
+function spaceLog(config: SpaceLogConfig, data: SpaceLogDataItem[]): void
+
+export { spaceLog }
+
+export default spaceLog

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const defaultHeading = 'Unknown'
 
 const spaceLog = (config, data) => {
   try {
-    const { columnKeys, headings } = config
+    const { columnKeys, headings, spaceSize = 1 } = config
 
     const hasHeadings = !!(headings && headings.length)
 
@@ -20,7 +20,7 @@ const spaceLog = (config, data) => {
       const headingLength = hasHeadings ? (headings[index]?.length || defaultHeading.length) : 0
       const dataLengths = data.map(item => item[key]?.length || 0)
 
-      columnWidths[key] = Math.max(headingLength, ...dataLengths) + 1
+      columnWidths[key] = Math.max(headingLength, ...dataLengths) + spaceSize
     })
 
     // Log Headings

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -50,6 +50,22 @@ describe('spaceLog', () => {
     expect(mockedConsoleLog).toHaveBeenNthCalledWith(6, '')
   })
 
+  it('logs a table with headings and extra space', () => {
+    spaceLog({
+      columnKeys: ['country', 'capital', 'flag'],
+      headings: ['Country', 'Capital', 'Flag'],
+      spaceSize: 2,
+    }, testData)
+
+    expect(mockedConsoleLog).toHaveBeenCalledTimes(6)
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '')
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '_Country_      _Capital_   _Flag_')
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, 'Brazil       Brasília  🇧🇷')
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(4, 'Japan        Tokyo     🇯🇵')
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(5, 'South Korea  Seoul     🇰🇷')
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(6, '')
+  })
+
   it('logs a table with a missing heading', () => {
     spaceLog({
       columnKeys: ['country', 'capital', 'flag'],


### PR DESCRIPTION
## Details

### What have you changed?

- Added spaceSize option to increase the space between cells.
- Added a TypeScript definition.

### Why are you making these changes?

- Some use-cases may prefer more than 1 space between columns.
- Projects using TypeScript will benefit from having available type definitions.
