### PR TITLE
Migrate from `depcheck` to `knip` ✂️

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,4 +1,0 @@
-ignores: [
-  "rimraf"
-]
-skip-missing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,5 @@ jobs:
         yarn build
         yarn test:bundles
 
-    - name: Depcheck
-      run: npx depcheck
+    - name: Code quality check
+      run: npx knip

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,4 @@
+{
+  "ignoreBinaries": ["knip"],
+  "ignoreDependencies": []
+}


### PR DESCRIPTION
## Details

### What have you changed?

- ✂️ Migrated from `depcheck` to `knip`.

### Why are you making these changes?

- ✂️ Depcheck is no longer actively maintained.

    Knip provides more accurate and comprehensive detection of unused dependencies, scripts, and exports compared to `depcheck`. This improves maintainability and reduced the risk of false positives or missed issues.
