### PR TITLE
Use PAT to allow workflows on changesets PR 🎟️

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,5 @@ jobs:
           createGithubReleases: true
           publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 🎟️ Updated release workflow to use PAT instead of default GitHub token

### Why are you making these changes?
<!-- List reasons in present tense -->
- 🎟️ Allows workflows to run on the Version Packages PR created by changesets
