### PR TITLE
Renamed `rollup.config.mjs` → `rollup.config.js` 🎢

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,17 +1,17 @@
-import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 import nodeResolve from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
 import typescript from '@rollup/plugin-typescript'
 import { defineConfig } from 'rollup'
 
-const esmRequire = createRequire(import.meta.url)
-const pkg = esmRequire('./package.json')
+const { dependencies, peerDependencies } = JSON.parse(readFileSync(resolve('./package.json'), 'utf-8'))
 
 const commonOptions = {
   external: [
-    ...Object.keys(pkg.dependencies || {}),
-    ...Object.keys(pkg.peerDependencies || {}),
+    ...Object.keys(dependencies || {}),
+    ...Object.keys(peerDependencies || {}),
   ],
   input: 'src/index.ts',
 }


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 📝 Renamed `rollup.config.mjs` to `rollup.config.js`.

### Why are you making these changes?
<!-- List reasons in present tense -->
- 📝 With `"type": "module"` in `package.json`, the `.mjs` extension is redundant. Using `.js` is simpler, more standard, and consistent with modern ES module practices.
