### PR TITLE
Type-safe columnKeys 🔐

### DIFF
--- a/.changeset/green-mice-grow.md
+++ b/.changeset/green-mice-grow.md
@@ -1,0 +1,5 @@
+---
+"space-log": minor
+---
+
+columnKeys are now type-safe — TypeScript infers the data item type and raises a compile-time error if a key doesn't exist on the data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,33 +16,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.18, 20.x, 22.x, 24.x, 26.x]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Enable Corepack
-      run: corepack enable
+      - name: Enable Corepack
+        run: corepack enable
 
-    - name: Install dependencies
-      run: yarn install --immutable
+      - name: Install dependencies
+        run: yarn install --immutable
 
-    - name: Type check
-      run: yarn tsc --noEmit
+      - name: Type check
+        run: yarn tsc --noEmit
 
-    - name: Unit tests
-      run: yarn test --coverage
+      - name: Unit tests
+        run: yarn test --coverage
 
-    - name: Integration tests
-      run: |
-        yarn build
-        yarn test:integration
+      - name: Integration tests
+        run: |
+          yarn build
+          yarn test:integration
 
-    - name: Check code quality
-      run: yarn knip
+      - name: Check code quality
+        run: yarn knip

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `spaceLog` function has two required arguments; `config` and `data`.
 
 | Property     | Type   | Required | Default | Description                                                |
 |--------------|--------|----------|---------|------------------------------------------------------------|
-| `columnKeys` | array  | ✅       | -       | Array of keys representing the `data[key]` of each column. |
+| `columnKeys` | array  | ✅       | -       | Array of keys representing the `data[key]` of each column. In TypeScript, these are inferred from the data type, so passing an unrecognised key is a compile-time error. |
 | `headings`   | array  | -        | -       | Column headings. If omitted, only data is shown.           |
 | `spaceSize`  | number | -        | 1       | Amount of whitespace around column content.                |
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
   },
   extensionsToTreatAsEsm: ['.ts'],
   testEnvironment: 'node',
+  testMatch: ['**/*.spec.ts'],
   transform: {
     '^.+\\.ts$': ['ts-jest', {
       tsconfig: {

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,4 @@
 {
-  "ignoreBinaries": [],
   "ignoreDependencies": [
     "@jest/globals",
     "ts-node"

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "terminal"
   ],
   "license": "MIT",
-  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728"
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53"
 }

--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -1,0 +1,31 @@
+type TestCountry = {
+  capital?: string
+  country: string
+  flag: string
+  isIslandNation?: boolean
+  population?: number
+}
+
+const TEST_DATA: ReadonlyArray<TestCountry> = [{
+  capital: 'Brasília',
+  country: 'Brazil',
+  flag: '🇧🇷',
+  isIslandNation: false,
+  population: 213,
+}, {
+  capital: 'Tokyo',
+  country: 'Japan',
+  flag: '🇯🇵',
+  isIslandNation: true,
+  population: 124,
+}, {
+  capital: 'Seoul',
+  country: 'South Korea',
+  flag: '🇰🇷',
+  isIslandNation: false,
+  population: 51,
+}]
+
+export {
+  TEST_DATA,
+}

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk'
 
 import { spaceLog } from '..'
 
+import { TEST_DATA } from './fixtures'
+
 jest.mock('chalk', () => ({
   blue: jest.fn().mockImplementation(text => text),
   green: jest.fn().mockImplementation(text => text),
@@ -11,26 +13,6 @@ jest.mock('chalk', () => ({
 describe('spaceLog', () => {
 
   const mockedConsoleLog = jest.spyOn(console, 'log').mockImplementation(text => text)
-
-  const TEST_DATA = [{
-    capital: 'Brasília',
-    country: 'Brazil',
-    flag: '🇧🇷',
-    isIslandNation: false,
-    population: 213,
-  }, {
-    capital: 'Tokyo',
-    country: 'Japan',
-    flag: '🇯🇵',
-    isIslandNation: true,
-    population: 124,
-  }, {
-    capital: 'Seoul',
-    country: 'South Korea',
-    flag: '🇰🇷',
-    isIslandNation: false,
-    population: 51,
-  }]
 
   it('does not log anything when there are no columnKeys', () => {
     spaceLog({
@@ -93,7 +75,7 @@ describe('spaceLog', () => {
       capital: 'Madrid',
       country: 'Spain',
       population: 3.5,
-      flag: '🇪🇸'
+      flag: '🇪🇸',
     }])
 
     expect(mockedConsoleLog).toHaveBeenCalledTimes(4)
@@ -108,7 +90,7 @@ describe('spaceLog', () => {
       columnKeys: ['country', 'capital', 'flag'],
     }, [...TEST_DATA, {
       country: 'South Africa',
-      flag: '🇿🇦'
+      flag: '🇿🇦',
     }])
 
     expect(mockedConsoleLog).toHaveBeenCalledTimes(4)
@@ -155,7 +137,7 @@ describe('spaceLog', () => {
         capital: 'London',
         country: 'United Kingdom',
         countryTheme: chalk.blue,
-        flag: '🇬🇧'
+        flag: '🇬🇧',
       }])
 
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
@@ -172,7 +154,7 @@ describe('spaceLog', () => {
         capitalTheme: chalk.green,
         country: 'United Kingdom',
         countryTheme: chalk.blue,
-        flag: '🇬🇧'
+        flag: '🇬🇧',
       }])
 
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
@@ -190,7 +172,7 @@ describe('spaceLog', () => {
         capital: 'London',
         country: 'United Kingdom',
         countryTheme: 'not a function',
-        flag: '🇬🇧'
+        flag: '🇬🇧',
       }])
 
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)

--- a/src/__tests__/types.spec.ts
+++ b/src/__tests__/types.spec.ts
@@ -3,7 +3,7 @@ import { spaceLog } from '..'
 import { TEST_DATA } from './fixtures'
 
 it('constrains columnKeys to keys present in the data', () => {
-  jest.spyOn(console, 'log').mockImplementation(() => true)
+  jest.spyOn(console, 'log').mockImplementation(() => {})
 
   spaceLog({ columnKeys: ['country', 'capital', 'flag', 'isIslandNation', 'population'] }, TEST_DATA)
   spaceLog({ columnKeys: ['country', 'capital'] }, TEST_DATA)

--- a/src/__tests__/types.spec.ts
+++ b/src/__tests__/types.spec.ts
@@ -1,0 +1,20 @@
+import { spaceLog } from '..'
+
+import { TEST_DATA } from './fixtures'
+
+it('constrains columnKeys to keys present in the data', () => {
+  jest.spyOn(console, 'log').mockImplementation(() => true)
+
+  spaceLog({ columnKeys: ['country', 'capital', 'flag', 'isIslandNation', 'population'] }, TEST_DATA)
+  spaceLog({ columnKeys: ['country', 'capital'] }, TEST_DATA)
+  spaceLog({ columnKeys: [] }, TEST_DATA)
+
+  // @ts-expect-error - 'city' is not a key of TestCountry
+  spaceLog({ columnKeys: ['city'] }, TEST_DATA)
+
+  // @ts-expect-error - 'city' is not a key of TestCountry
+  spaceLog({ columnKeys: ['country', 'city'] }, TEST_DATA)
+
+  // Assertion is intentionally minimal; compile-time checks are the primary goal.
+  expect(console.log).toHaveBeenCalled()
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk'
 
-import type { SpaceLogConfig, SpaceLogData } from './types'
+import type { SpaceLogConfig, SpaceLogData, SpaceLogDataItem } from './types'
 
-const spaceLog = (config: SpaceLogConfig, data: SpaceLogData): void => {
+const spaceLog = <T extends SpaceLogDataItem>(config: SpaceLogConfig<T>, data: SpaceLogData<T>): void => {
   const { columnKeys, headings, spaceSize = 1 } = config
 
   if (!columnKeys.length || !data.length) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,15 @@
-interface SpaceLogConfig {
-  columnKeys: readonly string[]
+interface SpaceLogConfig<T extends SpaceLogDataItem = SpaceLogDataItem> {
+  columnKeys: readonly (keyof T & string)[]
   headings?: readonly string[]
   spaceSize?: number
 }
 
-interface SpaceLogDataItem {
-  [key: string]: string | number | boolean | null | undefined | ((text: string) => string)
-}
+type SpaceLogDataItem = Record<string, string | number | boolean | null | undefined | ((text: string) => string)>
 
-type SpaceLogData = readonly SpaceLogDataItem[]
+type SpaceLogData<T extends SpaceLogDataItem = SpaceLogDataItem> = readonly T[]
 
 export type {
   SpaceLogConfig,
   SpaceLogData,
+  SpaceLogDataItem,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "rootDir": "src",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@ampproject/remapping@npm:^2.2.0":


### PR DESCRIPTION
## Details

### What have you changed?

- 🔐 Made `columnKeys` type-safe — TypeScript now infers the data type and raises a compile-time error if a key doesn't exist on the data

- 🧪 Added type-level tests using `@ts-expect-error` to assert the constraint holds

- 👉 Fixed indentation in test.yml and expanded the Node.js version matrix to include 26.x (with 18.x pinned to 18.18)

- 🛡️ Added npmMinimalAgeGate: 7d to .yarnrc.yml

- 📦 Bumped packageManager to yarn@4.15.0 in package.json

- 🔧 Cleaned up config files — removed empty ignoreBinaries from knip.json and added explicit types to tsconfig.json

### Why are you making these changes?

- 🔐 Catches invalid or mistyped column keys at compile time rather than silently rendering `-` at runtime

- 🧪 Ensures type safety works as expected.

- 👉 Keeps CI aligned with current and upcoming LTS Node versions

- 🛡️ Prevents newly published packages from being installed before they&#39;ve had time to be vetted

- 📦 Keeps Yarn up to date, needed for npmMinimalAgeGate.

- 🔧 Removes unnecessary noise and makes TypeScript type resolution more explicit
